### PR TITLE
tweak other container's max width to be in line with the increased character info width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -677,12 +677,6 @@ ul.chars{
     /* position: relative; */
 }
 
-@media screen and (max-width: 640px) {
-    .holder {
-        width: 90%;
-    }
-}
-
 .home-main {
     display: flex;
     width: 60%;
@@ -901,4 +895,17 @@ ul.chars{
     position: absolute;
     top: 50%;
     transform: translate(-50%, -50%);
+}
+
+@media screen and (max-width: 640px) {
+    .container-main,
+    .footer-container,
+    .holder,
+    .home-main,
+    .page-wide {
+        width: 90%;
+    }
+    #introVideo {
+        max-width: 80%;
+    }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -898,6 +898,9 @@ ul.chars{
 }
 
 @media screen and (max-width: 640px) {
+    .char-container {
+        width: 80%;
+    }
     .container-main,
     .footer-container,
     .holder,


### PR DESCRIPTION
i'd like to make `.char-container` the same 90% width, but setting `box-sizing: border-box` breaks some of the things on the site (like the discord button!) so i couldn't do that. in lieu of making a more involved change, just a more conservative increased width there.
