### PR TITLE
fix image overflow on features page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -599,9 +599,10 @@ ul.chars{
 }
 
 .feature-image {
-    max-height: 300px;
-    width: auto;
-    max-width: 500px;
+    max-height: 16em;
+    height: 100%;
+    width: 100%;
+    object-fit: contain;
 }
 
 .feature-paragraph {


### PR DESCRIPTION
this fixes the overflow of certain images and text on the features page when viewed on mobile.
it also centers the images (not the text).